### PR TITLE
Unwrap Spotify uri

### DIFF
--- a/ovos_audio_plugin_spotify/__init__.py
+++ b/ovos_audio_plugin_spotify/__init__.py
@@ -52,6 +52,7 @@ class SpotifyAudioService(AudioBackend):
         # once playback is started calling this will have no effect
 
     def add_list(self, tracks):
+        tracks = [t.replace("spotify://", "") for t in tracks]
         self.tracks += tracks
         LOG.info("Track list is " + str(tracks))
 


### PR DESCRIPTION
Spotify uri's start with "spotify:..." and not "spotify://" the audio
framework requires a :// to determine which service should be used.

To handle this, the skill will pre-pend a "spotify://" to the spotify
uri and the plugin will remove the spotify:// resulting in a proper
spotify uri.