### PR TITLE
Extract device list from response

### DIFF
--- a/ovos_audio_plugin_spotify/spotify_client.py
+++ b/ovos_audio_plugin_spotify/spotify_client.py
@@ -151,7 +151,8 @@ class SpotifyConnect(spotipy.Spotify):
             list of spotify devices connected to the user.
         """
         # TODO: Cache for a brief time
-        return self.devices()
+        devices = self.devices()
+        return devices.get('devices', [])
 
     def get_device(self, dev_id):
         for d in self.get_devices():


### PR DESCRIPTION
The device response was the raw returned dict and not the embedded list.